### PR TITLE
Add 2026 trimester dates to block-templates

### DIFF
--- a/src/lib/data/block-templates.tsx
+++ b/src/lib/data/block-templates.tsx
@@ -32,5 +32,21 @@ export const templates: { [key: string]: { name: string; startDate: string; endD
       startDate: "2025-11-17",
       endDate: "2026-02-08",
     },
+    /* 2026 dates */
+    {
+      name: "Trimester 1, 2026",
+      startDate: "2026-02-23",
+      endDate: "2026-06-21",
+    },
+    {
+      name: "Trimester 2, 2026",
+      startDate: "2026-07-06",
+      endDate: "2026-11-08",
+    },
+    {
+      name: "Trimester 3, 2026",
+      startDate: "2026-11-16",
+      endDate: "2027-02-07",
+    },
   ],
 };


### PR DESCRIPTION
Adds 2026 trimesters 1, 2 and 3 to the gradekeeper dropdown thing whatever it is.

Haven't tested so double check that it's inputted correctly, seems about right.

Used information from https://www.wgtn.ac.nz/__data/assets/pdf_file/0020/2319104/dates-2026.pdf and https://www.wgtn.ac.nz/__data/assets/pdf_file/0019/2319103/dates-2027.pdf.

Also still seeking thoughts on (as mentioned in #16):
> Also, one I'd like feedback on is adding a Full Academic Year option? This is Trimesters 1+2 and is very common in law courses across the entire country, and I imagine is used in some other contexts. While it is not reasonable to add every single combination that exists, I think this one is reasonable as it is a very common combination.
